### PR TITLE
Fix link upload failures

### DIFF
--- a/server/routes/upload.routes.js
+++ b/server/routes/upload.routes.js
@@ -9,7 +9,7 @@ const router = express.Router();
 router.post('/upload-file', upload.single('resourceFile'), uploadFileResource);
 
 // Route for UPLOADING LINKS (e.g., YouTube videos)
-// This does NOT need the multer middleware because there is no file
-router.post('/upload-link', uploadLinkResource);
+// Parse multipart form fields without files since frontend sends FormData
+router.post('/upload-link', upload.none(), uploadLinkResource);
 
 export default router;


### PR DESCRIPTION
Add `upload.none()` middleware to the `/upload-link` route to correctly parse multipart form data for link uploads.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7375aff-50f3-4668-a888-e4e762645e64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7375aff-50f3-4668-a888-e4e762645e64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

