### PR TITLE
Fix grading image visibility

### DIFF
--- a/src/pages/CGPACalculator.tsx
+++ b/src/pages/CGPACalculator.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import gradingImage from "@/assets/grading.jpeg";
 import Navigation from "@/components/Navigation";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -288,7 +289,7 @@ const CGPACalculator = () => {
                 This chart illustrates the points awarded for each grade, which are then used to calculate your CGPA.
               </p>
               <img
-                src="src/assets/grading.jpeg"
+                src={gradingImage}
                 alt="CGPA Calculation Chart based on Grades"
                 className="w-full h-auto rounded-md border border-gray-200 dark:border-gray-700 object-cover"
               />

--- a/src/types/assets.d.ts
+++ b/src/types/assets.d.ts
@@ -1,0 +1,24 @@
+declare module "*.png" {
+  const src: string
+  export default src
+}
+
+declare module "*.jpg" {
+  const src: string
+  export default src
+}
+
+declare module "*.jpeg" {
+  const src: string
+  export default src
+}
+
+declare module "*.svg" {
+  const src: string
+  export default src
+}
+
+declare module "*.gif" {
+  const src: string
+  export default src
+}


### PR DESCRIPTION
Fixes the broken grading image on the CGPA Calculator page.

The image was not visible because its `src` attribute used a string literal path, which Vite does not process as a bundled asset. This PR updates the component to import the image as a module and adds type declarations for image files to ensure proper bundling and TypeScript recognition.

---
<a href="https://cursor.com/background-agent?bcId=bc-d59918de-1816-4b38-98ee-072a53f84c06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d59918de-1816-4b38-98ee-072a53f84c06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

